### PR TITLE
Create $datadir only if there are no variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,8 +10,10 @@ class hiera(
     group => $group,
     mode  => '0644',
   }
-  file { $datadir:
-    ensure => directory,
+  if $datadir !~ /%{.*}/ {
+    file { $datadir:
+      ensure => directory,
+    }
   }
   # Template uses $hierarchy, $datadir
   file { $hiera_yaml:


### PR DESCRIPTION
Attached patch creates $datadir only if there are no variables in path (typically %{::environment}).
