### PR TITLE
enable multiple hiera backends to be specified, including configuration parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2013-11-18 Release 1.0.1
+Features:
+ - support multiple backends with arbitrary configuration
+
 2013-06-17 Release 0.3.1
 Bugfixes:
 - Docs!

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This class will write out a hiera.yaml file in either /etc/puppetlabs/puppet/hie
 
 ```puppet
 class { 'hiera':
+  backends => [
+    { 'yaml' => { 'datadir' => '/etc/puppet/hieradata' } },
+  ],
   hierarchy => [
     '%{environment}/%{calling_class}',
     '%{environment}',
@@ -19,14 +22,16 @@ class { 'hiera':
 The resulting output in /etc/puppet/hiera.yaml:
 ```yaml
 ---
-:backends: - yaml
+:backends:
+  - yaml
+
 :logger: console
+
 :hierarchy:
   - "%{environment}/%{calling_class}"
   - "%{environment}"
   - common
 
 :yaml:
-   :datadir: /etc/puppet/hieradata
+  :datadir: /etc/puppet/hieradata
 ```
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,15 +9,12 @@
 #   Default: empty
 #
 # [*backends*]
-#   Hiera backends.
-#   Default: ['yaml']
+#   array of Hiera backends, including configuration hashes
+#   Default: [ {'yaml' > { 'datadir' => $datadir } ]
+#            ($datadir auto-set, platform-specific
 #
 # [*hiera_yaml*]
 #   Heira config file.
-#   Default: auto-set, platform specific
-#
-# [*datadir*]
-#   Directory in which hiera will start looking for databases.
 #   Default: auto-set, platform specific
 #
 # [*owner*]
@@ -27,11 +24,6 @@
 # [*group*]
 #   Group owner of the files.
 #   Default: auto-set, platform specific
-#
-# [*extra_config*]
-#   An extra string fragment of YAML to append to the config file.
-#   Useful for configuring backend-specific parameters.
-#   Default: ''
 #
 # === Actions:
 #
@@ -46,6 +38,9 @@
 # === Sample Usage:
 #
 #   class { 'hiera':
+#     backends => [
+#       { 'yaml' => { 'datadir' => '/etc/puppet/hieradata' } },
+#     ],
 #     hierarchy => [
 #       '%{environment}',
 #       'common',
@@ -56,32 +51,29 @@
 #
 # Hunter Haugen <h.haugen@gmail.com>
 # Mike Arnold <mike@razorsedge.org>
+# Robin Bowes <robin.bowes@yo61.com>
 #
 # === Copyright:
 #
 # Copyright (C) 2012 Hunter Haugen, unless otherwise noted.
 # Copyright (C) 2013 Mike Arnold, unless otherwise noted.
+# Copyright (C) 2013 Robin Bowes, unless otherwise noted.
 #
-class hiera (
-  $hierarchy  = [],
-  $backends   = $hiera::params::backends,
-  $hiera_yaml = $hiera::params::hiera_yaml,
-  $datadir    = $hiera::params::datadir,
-  $owner      = $hiera::params::owner,
-  $group      = $hiera::params::group,
-  $extra_config   = '',
-) inherits hiera::params {
+
+class hiera(
+  $hierarchy    = $::hiera::params::hierarchy,
+  $hiera_yaml   = $::hiera::params::hiera_yaml,
+  $backends     = $::hiera::params::backends,
+  $owner        = $::hiera::params::owner,
+  $group        = $::hiera::params::group,
+) inherits ::hiera::params {
+
   File {
     owner => $owner,
     group => $group,
     mode  => '0644',
   }
-  if $datadir !~ /%{.*}/ {
-    file { $datadir:
-      ensure => directory,
-    }
-  }
-  # Template uses $hierarchy, $datadir
+  # Template uses $backends, $hierarchy
   file { $hiera_yaml:
     ensure  => present,
     content => template('hiera/hiera.yaml.erb'),
@@ -91,4 +83,5 @@ class hiera (
     ensure => symlink,
     target => $hiera_yaml,
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,17 +14,19 @@
 # Copyright (C) 2013 Mike Arnold, unless otherwise noted.
 #
 class hiera::params {
+
   if $::puppetversion =~ /Puppet Enterprise/ {
+    $backends   = [{'yaml' => {'datadir' => '/etc/puppetlabs/puppet/hieradata'}}]
     $hiera_yaml = '/etc/puppetlabs/puppet/hiera.yaml'
-    $datadir    = '/etc/puppetlabs/puppet/hieradata'
     $owner      = 'pe-puppet'
     $group      = 'pe-puppet'
   } else {
+    $backends   = [{'yaml' => {'datadir' => '/etc/puppet/hieradata'}}]
     $hiera_yaml = '/etc/puppet/hiera.yaml'
-    $datadir    = '/etc/puppet/hieradata'
     $owner      = 'puppet'
     $group      = 'puppet'
   }
 
-  $backends = ['yaml']
+  $hierarchy = []
+
 }

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -1,11 +1,18 @@
 ---
 :backends:
-<%= backends.to_yaml.split("\n")[1..-1].join("\n") %>
+<% @backends.each do |backend| -%>
+<%= backend.keys.to_yaml.split("\n")[1..-1].join("\n") %>
+<% end -%>
+
 :logger: console
 :hierarchy:
-<%= hierarchy.to_yaml.split("\n")[1..-1].join("\n") %>
+<%= @hierarchy.to_yaml.split("\n")[1..-1].join("\n") %>
 
-:yaml:
-   :datadir: <%= datadir %>
-
-<%= extra_config %>
+<% @backends.each do |backend| -%>
+<% backend.each_pair do |backend_name,config| -%>
+:<%= backend_name %>:
+<% config.each_pair do |key,value| -%>
+  :<%= key %>: <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
I've modified this module to allow multiple hiera backends to be specified, including any backend configuration.

If not specified, the backend config defaults to:
```
$backends = [ { 'yaml' => {'datadir' => $datadir} } ]
```