### PR TITLE
Stop Puppet 3 from squawking about variable access

### DIFF
--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -1,11 +1,11 @@
 ---
 :backends:
-<%= backends.to_yaml.split("\n")[1..-1].join("\n") %>
+<%= @backends.to_yaml.split("\n")[1..-1].join("\n") %>
 :logger: console
 :hierarchy:
-<%= hierarchy.to_yaml.split("\n")[1..-1].join("\n") %>
+<%= @hierarchy.to_yaml.split("\n")[1..-1].join("\n") %>
 
 :yaml:
-   :datadir: <%= datadir %>
+   :datadir: <%= @datadir %>
 
-<%= extra_config %>
+<%= @extra_config %>


### PR DESCRIPTION
```
...
Fri Nov 15 19:42:12 +0000 2013 Puppet (warning): Variable access via 'hierarchy' is deprecated. Use '@hierarchy' instead. template[/etc/puppet/modules/hiera/templates/hiera.yaml.erb]:5
   (at /etc/puppet/modules/hiera/templates/hiera.yaml.erb:5:in `result')
Fri Nov 15 19:42:12 +0000 2013 Puppet (warning): Variable access via 'datadir' is deprecated. Use '@datadir' instead. template[/etc/puppet/modules/hiera/templates/hiera.yaml.erb]:8
   (at /etc/puppet/modules/hiera/templates/hiera.yaml.erb:8:in `result')
...
```
