### PR TITLE
Fix invalid interval warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class hiera (
     group => $group,
     mode  => '0644',
   }
-  if $datadir !~ /%{.*}/ {
+  if $datadir !~ /%\{.*\}/ {
     file { $datadir:
       ensure => directory,
     }


### PR DESCRIPTION
Before this change, following warnings printed during execution:
/usr/lib/ruby/vendor_ruby/puppet/parser/lexer.rb:250: warning: regexp has invalid interval
/usr/lib/ruby/vendor_ruby/puppet/parser/lexer.rb:250: warning: regexp has `}' without escape

I've only lightly tested this on ubuntu 12.04 with hiera 1.3.2 and puppet 3.4.3. The warnings no longer appear, and it still seems to work as expected.
