### PR TITLE
add dependency 'puppetlabs/pe_gem' to fix #23

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/hunner/hunner-hiera'
 
 ## Add dependencies, if any:
 # dependency 'username/name', '>= 1.2.0'
+dependency 'puppetlabs/pe_gem', '>= 0.0.1'


### PR DESCRIPTION
I ran into this while testing the eyaml support a few minutes ago.  Tested dependency resolution works as intended by installing with PMT from a tarball with PE 3.3.2 on CentOS 6.5.
