### PR TITLE
Update opensource cmdpath

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class hiera::params {
     $owner      = 'puppet'
     $group      = 'puppet'
     $provider   = 'gem'
-    $cmdpath    = '/usr/bin/puppet'
+    $cmdpath    = '/usr/bin'
     $confdir    = '/etc/puppet'
   }
   $datadir_manage  = true


### PR DESCRIPTION
The opensource gem uses /usr/bin for the cmdpath.  'createkey' does not work with the current deafult path, and leads to this error:

Error: Could not find command '/usr/bin/puppet/eyaml'
Error: /Stage[main]/Hiera::Eyaml/Exec[createkeys]/returns: change from notrun to 0 failed: Could not find command '/usr/bin/puppet/eyaml'
