### PR TITLE
Fix eyaml key permissions

### DIFF
--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -42,7 +42,7 @@ class hiera::eyaml (
 
   file { "${confdir}/keys/private_key.pkcs7.pem":
     ensure  => file,
-    mode    => '0640',
+    mode    => '0600',
     owner   => $owner,
     group   => $group,
     require => Exec['createkeys'],


### PR DESCRIPTION
It makes sense for the public key to be readable by everyone.

Also, the mode 0604 is probably a typo.
