### PR TITLE
Fix eyaml first time key generation on Puppet open source

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class hiera::params {
     $owner      = 'puppet'
     $group      = 'puppet'
     $provider   = 'gem'
-    $cmdpath    = '/usr/bin/puppet'
+    $cmdpath    = '/usr/local/bin'
     $confdir    = '/etc/puppet'
   }
   $datadir_manage  = true


### PR DESCRIPTION
The regular gem provider will typically install to /usr/local/bin, not /usr/bin/puppet (which is a binary, not a directory). I was seeing error message like:

Error: Could not find command '/usr/bin/puppet/eyaml'

I've confirmed this fixes it on Ubuntu, and should be better than it being totally broken.

If there are other common gem directories then we could remove the cmdpath altogether (it's only used here), and instead use the path parameter to exec with an array. I don't know if there's a need for that, though.
