### PR TITLE
Fix key generation

### DIFF
--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -33,7 +33,7 @@ class hiera::eyaml (
   exec { 'createkeys':
     user    => $owner,
     cwd     => $confdir,
-    command => "${cmdpath}/eyaml createkeys",
+    command => 'eyaml createkeys',
     path    => $cmdpath,
     creates => "${confdir}/keys/private_key.pkcs7.pem",
     require => Package['hiera-eyaml'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,11 @@
 #   Note: You need to manage any package/gem dependancies
 #   Default: native
 #
+# [*cmdpath*]
+#   Search paths for command binaries, like the 'eyaml' command.
+#   The default should cover most cases.
+#   Default: ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
+#
 # === Actions:
 #
 # Installs either /etc/puppet/hiera.yaml or /etc/puppetlabs/puppet/hiera.yaml.
@@ -104,6 +109,7 @@ class hiera (
   $eyaml_extension = $hiera::params::eyaml_extension,
   $confdir         = $hiera::params::confdir,
   $logger          = $hiera::params::logger,
+  $cmdpath         = $hiera::params::cmdpath,
   $merge_behavior  = undef,
   $extra_config    = '',
 ) inherits hiera::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,6 @@ class hiera::params {
     $owner      = 'pe-puppet'
     $group      = 'pe-puppet'
     $provider   = 'pe_gem'
-    $cmdpath    = '/opt/puppet/bin'
     $confdir    = '/etc/puppetlabs/puppet'
   } else {
     $hiera_yaml = '/etc/puppet/hiera.yaml'
@@ -28,9 +27,9 @@ class hiera::params {
     $owner      = 'puppet'
     $group      = 'puppet'
     $provider   = 'gem'
-    $cmdpath    = '/usr/bin/puppet'
     $confdir    = '/etc/puppet'
   }
+  $cmdpath         = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
   $datadir_manage  = true
   $backends        = ['yaml']
   $logger          = 'console'


### PR DESCRIPTION
This fixes eyaml key generation on Puppet open source, which would error out with messages like:

```
Error: Could not find command '/usr/bin/puppet/eyaml'
```

As the eyaml binary may be in one of several directories depending on both OS and which gem provider is in use, switch to using a search path, and make it configurable.

This should cover both #30 and #32, and also work on Ubuntu versions where gems end up in /usr/local/bin.
