### PR TITLE
Make hiera::eyaml defaults come from base class

### DIFF
--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -12,10 +12,10 @@
 #
 class hiera::eyaml (
   $provider = $hiera::params::provider,
-  $owner    = $hiera::params::owner,
-  $group    = $hiera::params::group,
-  $cmdpath  = $hiera::params::cmdpath,
-  $confdir  = $hiera::params::confdir
+  $owner    = $hiera::owner,
+  $group    = $hiera::group,
+  $cmdpath  = $hiera::cmdpath,
+  $confdir  = $hiera::confdir
 ) inherits hiera::params {
 
   package { 'hiera-eyaml':


### PR DESCRIPTION
The hiera::eyaml defaults were coming from hiera::params, but so were
the defaults for the eponymous class. This requires passing the same
parameters to both classes.

This change lets the eyaml class pull the defaults from the eponymous
class and therefore not need duplicate values passed.
