### PR TITLE
Add new eyaml_pkcs7_public/private_key params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,51 +40,65 @@
 # Copyright (C) 2016 Vox Pupuli, unless otherwise noted.
 #
 class hiera (
-  $hierarchy            = $::hiera::params::hierarchy,
-  $backends             = ['yaml'],
-  $hiera_yaml           = $::hiera::params::hiera_yaml,
-  $create_symlink       = true,
-  $datadir              = $::hiera::params::datadir,
-  $datadir_manage       = true,
-  $owner                = $::hiera::params::owner,
-  $group                = $::hiera::params::group,
-  $provider             = $::hiera::params::provider,
-  $eyaml                = false,
-  $eyaml_name           = 'hiera-eyaml',
-  $eyaml_version        = undef,
-  $eyaml_source         = undef,
-  $eyaml_datadir        = undef,
-  $eyaml_extension      = undef,
-  $confdir              = $::hiera::params::confdir,
-  $puppet_conf_manage   = true,
-  $logger               = 'console',
-  $cmdpath              = $::hiera::params::cmdpath,
-  $create_keys          = true,
-  $keysdir              = undef,
-  $deep_merge_name      = 'deep_merge',
-  $deep_merge_version   = undef,
-  $deep_merge_source    = undef,
-  $deep_merge_options   = {},
-  $merge_behavior       = undef,
-  $extra_config         = '',
-  $master_service       = $::hiera::params::master_service,
-  $manage_package       = $::hiera::params::manage_package,
-  $package_name         = $::hiera::params::package_name,
-  $package_ensure       = $::hiera::params::package_ensure,
-  $eyaml_gpg_name       = 'hiera-eyaml-gpg',
-  $eyaml_gpg_version    = undef,
-  $eyaml_gpg_source     = undef,
-  $eyaml_gpg            = false,
-  $eyaml_gpg_recipients = undef,
+  $hierarchy               = $::hiera::params::hierarchy,
+  $backends                = ['yaml'],
+  $hiera_yaml              = $::hiera::params::hiera_yaml,
+  $create_symlink          = true,
+  $datadir                 = $::hiera::params::datadir,
+  $datadir_manage          = true,
+  $owner                   = $::hiera::params::owner,
+  $group                   = $::hiera::params::group,
+  $provider                = $::hiera::params::provider,
+  $eyaml                   = false,
+  $eyaml_name              = 'hiera-eyaml',
+  $eyaml_version           = undef,
+  $eyaml_source            = undef,
+  $eyaml_datadir           = undef,
+  $eyaml_extension         = undef,
+  $confdir                 = $::hiera::params::confdir,
+  $puppet_conf_manage      = true,
+  $logger                  = 'console',
+  $cmdpath                 = $::hiera::params::cmdpath,
+  $create_keys             = true,
+  $keysdir                 = undef,
+  $deep_merge_name         = 'deep_merge',
+  $deep_merge_version      = undef,
+  $deep_merge_source       = undef,
+  $deep_merge_options      = {},
+  $merge_behavior          = undef,
+  $extra_config            = '',
+  $master_service          = $::hiera::params::master_service,
+  $manage_package          = $::hiera::params::manage_package,
+  $package_name            = $::hiera::params::package_name,
+  $package_ensure          = $::hiera::params::package_ensure,
+  $eyaml_gpg_name          = 'hiera-eyaml-gpg',
+  $eyaml_gpg_version       = undef,
+  $eyaml_gpg_source        = undef,
+  $eyaml_gpg               = false,
+  $eyaml_gpg_recipients    = undef,
+  $eyaml_pkcs7_private_key = undef,
+  $eyaml_pkcs7_public_key  = undef,
 
   #Deprecated
-  $gem_source         = undef,
+  $gem_source              = undef,
 ) inherits ::hiera::params {
 
   if $keysdir {
     $_keysdir = $keysdir
   } else {
     $_keysdir = "${confdir}/keys"
+  }
+
+  if $eyaml_pkcs7_private_key {
+    $_eyaml_pkcs7_private_key = $eyaml_pkcs7_private_key
+  } else {
+    $_eyaml_pkcs7_private_key = "${_keysdir}/private_key.pkcs7.pem"
+  }
+
+  if $eyaml_pkcs7_public_key {
+    $_eyaml_pkcs7_public_key = $eyaml_pkcs7_public_key
+  } else {
+    $_eyaml_pkcs7_public_key = "${_keysdir}/public_key.pkcs7.pem"
   }
 
   if $eyaml_source {

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -21,8 +21,8 @@ end -%>
 <% if @eyaml_extension -%>
   :extension: <%= @eyaml_extension %>
 <% end -%>
-  :pkcs7_private_key: <%= @_keysdir %>/private_key.pkcs7.pem
-  :pkcs7_public_key:  <%= @_keysdir %>/public_key.pkcs7.pem
+  :pkcs7_private_key: <%= @_eyaml_pkcs7_private_key %>
+  :pkcs7_public_key:  <%= @_eyaml_pkcs7_public_key %>
 <% end -%>
 <% if @eyaml_gpg -%>
   :encrypt_method: "gpg"


### PR DESCRIPTION
This commit adds two new optional parameters.
These are eyaml_pkcs7_public_key and eyaml_pkcs7_private_key.

If specified, the values will be used in the generated hiera.yaml file.
If not given, behaviour remains unchanged and the keys are assumed to be
in the 'keysdir' directory.

This change allows more complicated hiera eyaml configuration.  For
example, my current manually configured hiera.yaml contains...
```
:eyaml:
  :pkcs7_private_key: /etc/puppet/keys/%{::product}/private_key.pkcs7.pem
  :pkcs7_public_key:  /etc/puppet/keys/public/%{::product}_key.pkcs7.pem
```

I have multiple sets of keys, (one pair per 'product'), and the private
and public keys aren't in the same directory.