### PR TITLE
Replace `to_yaml` in hiera.yaml template

### DIFF
--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -24,6 +24,23 @@ describe 'hiera' do
         it { should contain_package('hiera') }
       end
       describe 'hiera.yaml template' do
+        describe ':hierarchy: section' do
+          let(:params) { {
+            hierarchy: [
+              '%{environment}/%{calling_class}',
+              '%{environment}',
+              'common',
+            ]
+          } }
+          it 'should render correctly' do
+            content = catalogue.resource('file', '/etc/puppet/hiera.yaml').send(:parameters)[:content]
+            hierarchy_section  = %(:hierarchy:\n)
+            hierarchy_section += %(  - "%{environment}/%{calling_class}"\n)
+            hierarchy_section += %(  - "%{environment}"\n)
+            hierarchy_section += %(  - common\n)
+            expect(content).to include(hierarchy_section)
+          end
+        end
         context 'when eyaml = false' do
           it 'should not contain :eyaml: section' do
             content = catalogue.resource('file', '/etc/puppet/hiera.yaml').send(:parameters)[:content]
@@ -120,6 +137,25 @@ describe 'hiera' do
         } }
         it { should contain_class('hiera::eyaml') }
         it { should contain_class('hiera::deep_merge') }
+      end
+      describe 'hiera.yaml template' do
+        describe ':hierarchy: section' do
+          let(:params) { {
+            hierarchy: [
+              '%{environment}/%{calling_class}',
+              '%{environment}',
+              'common',
+            ]
+          } }
+          it 'should render correctly' do
+            content = catalogue.resource('file', '/etc/puppet/hiera.yaml').send(:parameters)[:content]
+            hierarchy_section  = %(:hierarchy:\n)
+            hierarchy_section += %(  - "%{environment}/%{calling_class}"\n)
+            hierarchy_section += %(  - "%{environment}"\n)
+            hierarchy_section += %(  - common\n)
+            expect(content).to include(hierarchy_section)
+          end
+        end
       end
     end
     context 'pe puppet 2015.2' do

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -5,12 +5,12 @@
   @backends.unshift('eyaml')
   @backends = @backends.uniq
 end -%>
-<%= @backends.to_yaml.split("\n")[1..-1].map{|e| "  #{e.strip}"}.join("\n") %>
+<%= @backends.map{|x| "  - #{x}"}.join("\n") %>
 
 :logger: <%= @logger %>
 
 :hierarchy:
-<%= @hierarchy.to_yaml.split("\n")[1..-1].map{|e| "  #{e.strip}"}.join("\n") %>
+<%= @hierarchy.map{|x| x  =~ /%/ ? "  - \"#{x}\"" : "  - #{x}"}.join("\n") %>
 
 :yaml:
   :datadir: <%= @datadir %>


### PR DESCRIPTION
`to_yaml` produced different output based on both ruby and puppet
version.  With this change, any hierarchy line containing a `%` is
always surrounded by double quotes.  This matches the formatting shown
in the README.
https://github.com/voxpupuli/puppet-hiera#beginning-with-hiera