### PR TITLE
documentation updates for version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ Note: this is the first release of the module in the voxpupuli namespace.
 ### Bugfixes:
 - Only ensure datadir if it does not have `%{.*}`
 
-[2.1.0]: https://github.com/hunner/puppet-hiera/compare/2.0.1...2.1.0
+[2.1.0]: https://github.com/hunner/puppet-hiera/compare/2.0.1...v2.1.0
 [2.0.1]: https://github.com/hunner/puppet-hiera/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/hunner/puppet-hiera/compare/1.4.1...2.0.0
 [1.4.1]: https://github.com/hunner/puppet-hiera/compare/1.4.0...1.4.1

--- a/README.md
+++ b/README.md
@@ -69,17 +69,15 @@ This module will also allow you to configure different options for logger and me
 
 For details and valid options see [Configuring Hiera](https://docs.puppetlabs.com/hiera/1/configuring.html#global-settings).
 
-**Note:** For `merge_behavior` if you set deep or deeper you need to ensure the deep_merge Ruby gem is installed.
-
 ```puppet
 class { 'hiera':
-  hierarchy => [
+  hierarchy      => [
     '%{environment}/%{calling_class}',
     '%{environment}',
     'common',
   ],
-  logger    => 'console',
-  merge_behavior => 'deep'
+  logger         => 'console',
+  merge_behavior => 'deeper'
 }
 ```
 
@@ -97,7 +95,8 @@ The resulting output in /etc/puppet/hiera.yaml:
 
 :yaml:
    :datadir: /etc/puppet/hieradata
-:merge_behavior: deep
+
+:merge_behavior: deeper
 ```
 
 ### Hiera-Eyaml-GPG
@@ -153,7 +152,7 @@ gpg --batch --homedir /etc/puppetlabs/code-staging/keys/gpg --gen-key /tmp/gpg_a
 
 ```puppet
 class { 'hiera':
-  hierarchy => [
+  hierarchy            => [
     'nodes/%{::clientcert}',
     'locations/%{::location}',
     'environments/%{::applicationtier}',
@@ -324,7 +323,7 @@ The following parameters are available for the hiera class:
 
 ## Limitations
 
-The pe-puppetserver service must be restarted after hiera-eyaml is installed; this module will not do it for you. The `eyaml_version` parameter does not currently modify the eyaml version of the command-line gem on pe-puppetserver.
+The `eyaml_version` parameter does not currently modify the eyaml version of the command-line gem on pe-puppetserver.
 
 ## Development
 


### PR DESCRIPTION
- unlike previous versions, tag has a leading 'v', i.e. v2.1.0
- module installs deep_merge gem automatically
- according to documentation one would almost never use 'deep' merge behavior, use more widely used 'deeper' as an example
- puppet server is correctly restarted when gems are installed