### PR TITLE
Update metadata.json to not give dependency errors in puppet3.8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,11 @@
   "issues_url": "https://github.com/voxpupuli/puppet-hiera/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.3.1 < 5.0.0"
     },
     {
-      "name": "puppetlabs-inifile",
+      "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],


### PR DESCRIPTION
On puppet3.8 there are dependency errors listed due to the use of hyphens rather than forward slashes in the metadata.json file:

```
root@testbox:/etc/puppet/modules/hiera# puppet module list
Warning: Missing dependency 'puppetlabs-inifile':
  'hunner-hiera' (v2.0.1) requires 'puppetlabs-inifile' (>= 1.0.0 < 2.0.0)
Warning: Missing dependency 'puppetlabs-stdlib':
  'hunner-hiera' (v2.0.1) requires 'puppetlabs-stdlib' (>= 4.3.1 < 5.0.0)
/etc/puppet/modules
├── hunner-hiera (v2.0.1)
├── puppetlabs-inifile (v1.5.0)
└── puppetlabs-stdlib (v4.12.0)
```

Altering the hyphens to forward slashes resolves this:

```
root@stackstorm:/etc/puppet/modules/hiera# puppet module list
/etc/puppet/modules
├── hunner-hiera (v2.0.1)
├── puppetlabs-inifile (v1.5.0)
└── puppetlabs-stdlib (v4.12.0)
```

I know that you guys like to have tests for fixes, but I am unsure how to write a test for problems such as this one...