### PR TITLE
Fixes #153 - Add support for 3rd party backends

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - .vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
+
 Lint/ConditionPosition:
   Enabled: True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 All notable changes to this project will be documented in this file.
 
+## 2016-XX-XX Release 2.2.0
+* Add support for 3rd party backends #153
+This module now supports configuration of any backend via a new backend_options
+parameter.
+
 ## 2016-08-31 Release 2.1.2
 
 * Modulesync with latest Vox Pupuli defaults

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ class { 'hiera':
 }
 ```
 
+
 The resulting output in /etc/puppet/hiera.yaml:
 
 ```yaml
@@ -210,6 +211,33 @@ The following parameters are available for the hiera class:
 * `backends`  
   The list of backends.  
   Default: `['yaml']`
+  If you supply a additional backend you must also supply the backend data in
+  the `backend_options` hash.
+* `backend_options`
+  An optional hash of backend data for **any** backend.
+  Each key in the hash should be the name of the backend as listed in
+  the `backends` array.  You can also supply additional settings for the backend
+  by passing in a hash.  By default the `yaml` and `eyaml` backend data will be added
+  if you enable them via their respective parameters.  Any options you supply
+  for `yaml` and `eyaml` backend types will always override other parameters supplied
+  to the hiera class for that backend.
+
+  Example hiera data for the backend_options hash:
+
+  ```yaml
+  backend_options:
+    json:
+      datadir: '/etc/puppetlabs/puppet/%{::environment}/jsondata'
+    redis:
+      password: clearp@ssw0rd        # if your Redis server requires authentication
+      port: 6380                     # unless present, defaults to 6379
+      db: 1                          # unless present, defaults to 0
+      host: db.example.com           # unless present, defaults to localhost
+      path: /tmp/redis.sock          # overrides port if unixsocket exists
+      soft_connection_failure: true  # bypass exception if Redis server is unavailable; default is false
+      separator: /                   # unless present, defaults to :
+      deserialize: :json             # Try to deserialize; both :yaml and :json are supported
+  ```
 * `hiera_yaml`  
   The path to the hiera config file.  
   **Note**: Due to a bug, hiera.yaml is not placed in the codedir. Your puppet.conf `hiera_config` setting must match the configured value; see also `hiera::puppet_conf_manage`

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
-require 'puppet-strings/rake_tasks'
+#require 'puppet-strings/rake_tasks'
 
 if RUBY_VERSION >= '2.3.0'
   require 'rubocop/rake_task'

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -1,38 +1,17 @@
 # managed by puppet
 ---
-:backends:
-<% if @eyaml
-  @backends.unshift('eyaml')
-  @backends = @backends.uniq
-end -%>
-<%= @backends.map{|x| "  - #{x}"}.join("\n") %>
+<%= { 'backends' => @requested_backends }.to_yaml.gsub(/---\s+/, '') %>
 
 :logger: <%= @logger %>
 
 :hierarchy:
 <%= @hierarchy.map{|x| x  =~ /%/ ? "  - \"#{x}\"" : "  - #{x}"}.join("\n") %>
+<% @requested_backends.each do | backend_name | -%>
+<%# dump all the backend data to yaml format %>
+<%= { backend_name => @backend_data[backend_name] }.to_yaml.gsub(/---\s+/, '') -%>
+<%- end -%>
 
-:yaml:
-  :datadir: <%= @datadir %>
-<% if @eyaml -%>
-
-:eyaml:
-  :datadir: <%= @eyaml_real_datadir %>
-<% if @eyaml_extension -%>
-  :extension: <%= @eyaml_extension %>
-<% end -%>
-  :pkcs7_private_key: <%= @_eyaml_pkcs7_private_key %>
-  :pkcs7_public_key:  <%= @_eyaml_pkcs7_public_key %>
-<% end -%>
-<% if @eyaml_gpg -%>
-  :encrypt_method: "gpg"
-  :gpg_gnupghome: "<%= @_keysdir-%>/gpg"
-<% if @eyaml_gpg_recipients -%>
-  :gpg_recipients: "<%= @eyaml_gpg_recipients %>"
-<% end -%>
-<% end -%>
 <% if @merge_behavior -%>
-
 :merge_behavior: <%= @merge_behavior %>
 <% end -%>
 <% if @merge_behavior == 'deep' && !@deep_merge_options.empty? -%>


### PR DESCRIPTION
  * previously this module only allowed for configuration of
    eyaml and yaml backend types.  So any time a new backend
    was used the user was forced to abandon this module and
    fork the code to accommodate their special backend.

    This commit fixes the issue by allowing the user to pass
    in a hash of backend configuration data for not only yaml
    and eyaml but also any other backend type.

    This change maintains backwards compatibility with previous versions
    and allows the user to supply additional backends very easily.