### PR TITLE
make eyaml be the first backend

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,9 +142,9 @@ class hiera (
       true  => $datadir,
     }
     # the requested_backends has a side affect in that the eyaml will always be
-    # last for backend lookups.  This can be fixed by specifing the order in
+    # first for backend lookups.  This can be fixed by specifing the order in
     # the backends parameter ie. ['yaml', 'eyaml', 'redis']
-    $requested_backends = unique(concat($backends, 'eyaml'))
+    $requested_backends = unique(concat(['eyaml'], $backends))
   } else {
     $requested_backends = $backends
     $eyaml_real_datadir = undef

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -130,7 +130,7 @@ describe 'hiera' do
 
         it 'include backends' do
           backends = YAML.load(content)[:backends]
-          expect(backends).to eq(%w(yaml eyaml json yamll))
+          expect(backends).to eq(%w(eyaml yaml json yamll))
         end
         it 'include json backend' do
           backend = YAML.load(content)[:json]
@@ -190,7 +190,7 @@ describe 'hiera' do
           end
           it 'include eyaml-gpg backend with eyaml unspecified' do
             backends = YAML.load(content)[:backends]
-            expect(backends).to eq(%w(yaml eyaml))
+            expect(backends).to eq(%w(eyaml yaml))
             eyaml_backend = YAML.load(content)[:eyaml]
             expect(eyaml_backend[:datadir]).to eq('/etc/puppetlabs/code/environments/%{::environment}/hieradata')
             expect(eyaml_backend[:encrypt_method]).to eq('gpg')
@@ -320,7 +320,7 @@ describe 'hiera' do
 
         it 'include backends' do
           backends = YAML.load(content)[:backends]
-          expect(backends).to eq(%w(yaml eyaml json yamll))
+          expect(backends).to eq(%w(eyaml yaml json yamll))
         end
         it 'include json backend' do
           backend = YAML.load(content)[:json]
@@ -380,7 +380,7 @@ describe 'hiera' do
           end
           it 'include eyaml-gpg backend with eyaml unspecified' do
             backends = YAML.load(content)[:backends]
-            expect(backends).to eq(%w(yaml eyaml))
+            expect(backends).to eq(%w(eyaml yaml))
             eyaml_backend = YAML.load(content)[:eyaml]
             expect(eyaml_backend[:datadir]).to eq('/etc/puppetlabs/code/environments/%{::environment}/hieradata')
             expect(eyaml_backend[:encrypt_method]).to eq('gpg')


### PR DESCRIPTION
older versions of this module had eyaml listed as the first
backend. people who use eyaml need eyaml as the first back end,
otherwise the encrypted valued will be read in as plain yaml and never
decrypted.

ref https://github.com/voxpupuli/puppet-hiera/issues/161