### PR TITLE
Do not make files in the gnupg home executable.

### DIFF
--- a/manifests/eyaml_gpg.pp
+++ b/manifests/eyaml_gpg.pp
@@ -46,6 +46,6 @@ class hiera::eyaml_gpg {
     ensure  => directory,
     recurse => true,
     purge   => false,
-    mode    => '0700',
+    mode    => '0600',
   }
 }


### PR DESCRIPTION
Puppet will translate the mode of 0600 to 0700 for the directory,
not the other way around.