### PR TITLE
Support deep_merge_options with 'deeper' merge_behavior

### DIFF
--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -18,7 +18,7 @@
 <% if @merge_behavior -%>
 :merge_behavior: <%= @merge_behavior %>
 <% end -%>
-<% if @merge_behavior == 'deep' && !@deep_merge_options.empty? -%>
+<% if (@merge_behavior == 'deep' || @merge_behaviour == 'deeper') && !@deep_merge_options.empty? -%>
 :deep_merge_options:
   <%- @deep_merge_options.each do |option_key, option_value| -%>
   :<%= option_key %>: <%= option_value %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

The `deep_merge_options` parameter should be respected when `merge_behavior => 'deeper'`, especially since 'deeper' is really the only useful of the two non-native behavior options (see https://docs.puppet.com/hiera/3.2/configuring.html#mergebehavior).