### PR TITLE
Strict variables fix for `pe_server_version`

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class hiera::params {
   } else {
     if $::puppetversion and versioncmp($::puppetversion, '4.0.0') >= 0 {
       # Configure for AIO packaging.
-      if $::pe_server_version {
+      if getvar('::pe_server_version') {
         $master_service = 'pe-puppetserver'
         $provider       = 'puppetserver_gem'
       } else {
@@ -55,7 +55,7 @@ class hiera::params {
       $datadir        = "${confdir}/hieradata"
       $manage_package = true
     }
-    if $::pe_server_version {
+    if getvar('::pe_server_version') {
       $owner = 'pe-puppet'
       $group = 'pe-puppet'
     } else {

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -7,8 +7,7 @@ describe 'hiera' do
         {
           puppetversion: '3.8.6',
           is_pe: false,
-          pe_version: '0.0.0',
-          pe_server_version: '0.0.0'
+          pe_version: '0.0.0'
         }
       end
       describe 'default params' do
@@ -301,8 +300,7 @@ describe 'hiera' do
         {
           puppetversion: Puppet.version,
           is_pe: false,
-          pe_version: '0.0.0',
-          pe_server_version: '0.0.0'
+          pe_version: '0.0.0'
         }
       end
       describe 'default params' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.

-->

https://blog.yo61.com/test-for-undefined-fact-in-puppet-with-strict_variables

`getvar()` has better compatibility that `defined()` which is broken in
early puppet 3 versions.

After migrating the module to puppet 4, we will then be able to use the
facts hash instead.

Fixes #GH-171