### PR TITLE
Use default value for hiera_config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -231,7 +231,7 @@ class hiera (
       path    => "${confdir}/puppet.conf",
       section => 'main',
       setting => 'hiera_config',
-      value   => $hiera_yaml,
+      value   => '$confdir/hiera.yaml',
     }
     $master_subscribe = [
       File[$hiera_yaml],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,8 +19,8 @@ class hiera::params {
   $package_name   = 'hiera'
   $hierarchy      = []
   if str2bool($::is_pe) {
-    $hiera_yaml     = '/etc/puppetlabs/puppet/hiera.yaml'
-    $datadir        = '/etc/puppetlabs/puppet/hieradata'
+    $hiera_yaml     = "${confdir}/hiera.yaml"
+    $datadir        = "${confdir}/hieradata"
     $owner          = 'pe-puppet'
     $group          = 'pe-puppet'
     $cmdpath        = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']


### PR DESCRIPTION
This is necessary when the module [theforeman/puppet](https://github.com/theforeman/puppet-puppet) is used.

Otherwise `theforeman/puppet` will change the value of `hiera_config` to `$confdir/hiera.yaml` and `puppet/hiera` will change it back to `/etc/puppetlabs/puppet/hiera.yaml`.

@hunner Do you have link to the issue regarding Puppet Enterprise does not use `/etc/puppetlabs/code/environments/${::environment}/hiera.yaml`?