### PR TITLE
Update the version requirement for the inifile module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ end
 
 group :test do
   gem 'puppetlabs_spec_helper', '~> 2.6.0',                         :require => false
-  gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
@@ -30,6 +29,13 @@ group :test do
   gem 'simplecov-console',                                          :require => false
   gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
   gem 'parallel_tests',                                             :require => false
+
+  # Currently, rspec-puppet versions > 2.6.11 break spec tests for Puppet 4
+  if ENV['PUPPET_VERSION'] == '~> 4.0'
+    gem 'rspec-puppet', '<= 2.6.11', :require => false
+  else
+    gem 'rspec-puppet', '~> 2.5', :require => false
+  end
 end
 
 group :development do

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.4.1 < 2.0.0"
+      "version_requirement": ">= 1.4.1 < 3.0.0"
     }
   ],
   "data_provider": null,


### PR DESCRIPTION
#### Pull Request (PR) description
The version requirement for the `inifile` module is old, so commands like the following raise warnings:

```sh
# puppet module list --tree --environment=tex_misc >/dev/null
Warning: Module 'puppetlabs-inifile' (v2.2.0) fails to meet some dependencies:
  'puppet-hiera' (v3.3.2) requires 'puppetlabs-inifile' (>= 1.4.1 < 2.0.0)
```

We have been using version 2.2.0 for a while with no issues.  This caps the version at 3.0.0 to prevent going to the next major release without testing.

Additionally, while testing this on Puppet 4, the spec tests were mostly broken from what turned out to be `rspec-puppet`.  This PR also contains a fix in the Gemfile to use a safe version of `rspec-puppet` for Puppet 4 tests, and to use the latest version for Puppet 5 tests.

#### This Pull Request (PR) fixes the following issues
Fixes #214 
Fixes #224 
