### PR TITLE
README.md: correct default of hiera5_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ The following parameters are available for the hiera class:
   For Hiera verison 5.
   Default: `[{}]`
 * `hiera5_defaults`
-  To set hiera 5 defaults. e.g. datadir, data_hash
-  Default: `{}`
+  To set hiera 5 defaults. e.g. `datadir`, `data_hash`.
+  Default: `{'datadir' => 'data', 'data_hash' => 'yaml_data'}`
 * `hiera_version`
   Version format to layout hiera.yaml.
   Should be a string.


### PR DESCRIPTION
The default was changed in commit 650f144335d2e08cf93cf43139c25be2784ddc9b but README.md was not updated.