### PR TITLE
README.md: remove note about FOSS Puppet 3 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ The following parameters are available for the hiera class:
   A hash of options to set in hiera.yaml for the deep merge behavior.
   Default: `{}`
 * `manage_package`
-  A boolean for wether the hiera package should be managed. Defaults to `true` on
-  FOSS 3 but `false` otherwise.
+  A boolean for wether the hiera package should be managed.
+  Default: `false`
 * `package_name`
   Specifies the name of the hiera package. Default: 'hiera'
 * `package_ensure`


### PR DESCRIPTION
This note should have been removed with commit bc3b1ccbb8908c1ea823aaf05da804ded072ad69, which dropped Puppet 3 support.