### PR TITLE
Change hiera_yaml to ensure file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -262,7 +262,7 @@ class hiera (
     default:  { $hiera_template = template('hiera/hiera.yaml.erb') }    # Apply erb for default version 3
   }
   file { $hiera_yaml:
-    ensure  => present,
+    ensure  => file,
     content => $hiera_template,
   }
   # Symlink for hiera command line tool


### PR DESCRIPTION
#### Pull Request (PR) description

If $hiera_yaml already exists as a symbolic link on a target system the puppet run will not replace this link with a file. Anyway in my opinion there's no reason why this file resource is set to "ensure => present" instead of "ensure => file". So, I replaced it with file.
