### PR TITLE
add options as a valid hiera5_defaults setting

### DIFF
--- a/templates/hiera.yaml.epp
+++ b/templates/hiera.yaml.epp
@@ -8,7 +8,15 @@ version: <%= $hiera_version %>
 defaults:
 <%- if $hiera5_defaults { -%>
 <%- $hiera5_defaults.each |$dk, $dv| { -%>
+<%- if $dv =~ Hash[String,String] { -%>
+  <%= $dk -%>:
+<%- $dv.each |$ddk, $ddv| { -%>
+    <%= $ddk -%>: <%= $ddv %>
+<%- } -%>
+<%- } -%>
+<%- else { -%>
   <%= $dk -%>: <%= $dv %>
+<% } -%>
 <% } -%>
 <% } -%>
 hierarchy:

--- a/types/hiera5_defaults.pp
+++ b/types/hiera5_defaults.pp
@@ -4,5 +4,6 @@ type Hiera::Hiera5_defaults = Struct[{
                                 data_hash       =>  Enum['yaml_data', 'json_data', 'hocon_data'],
                                 lookup_key      =>  Optional[String],
                                 data_dig        =>  Optional[String],
-                                hiera3_backend  =>  Optional[String]
+                                hiera3_backend  =>  Optional[String],
+                                options         =>  Optional[Hash],
                               }]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds support for "options" under hiera5_defaults, which is useful in a variety of situations, including eyaml configuration.  For example:
```
    hiera5_defaults         => {
      'datadir'   => "${::settings::codedir}/environments/%{::environment}/hieradata",
      'data_hash' => 'yaml_data',
      'options'   => {
        'pkcs7_private_key' => '/etc/pki/eyaml/private_key.pkcs7.pem',
        'pkcs7_public_key'  => '/etc/pki/eyaml/public_key.pkcs7.pem',
      },
    },
```

#### This Pull Request (PR) fixes the following issues
There is no issue open at this time that I believe matches up with this PR.