### PR TITLE
Make `data_hash` in `hiera5_defaults` optional

### DIFF
--- a/types/hiera5_defaults.pp
+++ b/types/hiera5_defaults.pp
@@ -1,9 +1,9 @@
 # This will validate hiera 5 'defaults' hash
 type Hiera::Hiera5_defaults = Struct[{
-                                datadir         =>  Optional[String],
-                                data_hash       =>  Enum['yaml_data', 'json_data', 'hocon_data'],
-                                lookup_key      =>  Optional[String],
-                                data_dig        =>  Optional[String],
-                                hiera3_backend  =>  Optional[String],
-                                options         =>  Optional[Hash],
+                                datadir        => Optional[String],
+                                data_hash      => Optional[Enum['yaml_data', 'json_data', 'hocon_data']],
+                                lookup_key     => Optional[String],
+                                data_dig       => Optional[String],
+                                hiera3_backend => Optional[String],
+                                options        => Optional[Hash],
                               }]


### PR DESCRIPTION
https://puppet.com/docs/puppet/5.3/hiera_config_yaml_5.html#backend-key
> Used for any hierarchy level that doesn't specify its own. This must be one of:
> * data_hash - produces a hash of key-value pairs (typically from a data file)
> * lookup_key - produces values key by key (typically for a custom backend)
> * data_dig - produces values key by key (for more advanced backends)
> * hiera3_backend - global layer only