### PR TITLE
 Update inifile compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.4.1 < 3.0.0"
+      "version_requirement": ">= 1.4.1 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Update puppet module inifile compatibility to versions under 4.0.0.

With the latest version of inifile on hiera 3.4.0, ```puppet module list --tree```
resulted in:

    Warning: Module 'puppetlabs-inifile' (v3.0.0) fails to meet some dependencies:
      'puppet-hiera' (v3.4.0) requires 'puppetlabs-inifile' (>= 1.4.1 < 3.0.0)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
