### PR TITLE
Hiera file permission updates

### DIFF
--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -16,8 +16,8 @@ class hiera::eyaml {
   $eyaml_version = $::hiera::eyaml_version
   $eyaml_source  = $::hiera::_eyaml_source
 
-  $owner         = $::hiera::owner
-  $group         = $::hiera::group
+  $owner         = $::hiera::eyaml_owner
+  $group         = $::hiera::eyaml_group
   $cmdpath       = $::hiera::cmdpath
   $confdir       = $::hiera::confdir
   $create_keys   = $::hiera::create_keys

--- a/manifests/eyaml_gpg.pp
+++ b/manifests/eyaml_gpg.pp
@@ -12,8 +12,8 @@ class hiera::eyaml_gpg {
   $ruby_gpg_version  = $::hiera::ruby_gpg_version
   $ruby_gpg_source   = $::hiera::ruby_gpg_source
 
-  $owner             = $::hiera::owner
-  $group             = $::hiera::group
+  $owner             = $::hiera::eyaml_owner
+  $group             = $::hiera::eyaml_group
   $cmdpath           = $::hiera::cmdpath
   $_keysdir          = $::hiera::_keysdir
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,8 +66,8 @@ class hiera (
   $datadir_manage                           = true,
   $owner                                    = $::hiera::params::owner,
   $group                                    = $::hiera::params::group,
-  $eyaml_owner                              = $::hiera::params::owner,
-  $eyaml_group                              = $::hiera::params::group,
+  $eyaml_owner                              = $::hiera::params::eyaml_owner,
+  $eyaml_group                              = $::hiera::params::eyaml_group,
   $provider                                 = $::hiera::params::provider,
   $eyaml                                    = false,
   $eyaml_name                               = 'hiera-eyaml',
@@ -250,7 +250,7 @@ class hiera (
   # Determine hiera version
   case $hiera_version {
     '5':  { if ($hierarchy !~ Hiera::Hiera5_hierarchy) {
-              fail("${hierarchy} should be an array of hash")
+              fail('`hierarchy` should be an array of hash')
             }
             else
               { $hiera_template = epp('hiera/hiera.yaml.epp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,8 @@ class hiera (
   $datadir_manage                           = true,
   $owner                                    = $::hiera::params::owner,
   $group                                    = $::hiera::params::group,
+  $eyaml_owner                              = $::hiera::params::owner,
+  $eyaml_group                              = $::hiera::params::group,
   $provider                                 = $::hiera::params::provider,
   $eyaml                                    = false,
   $eyaml_name                               = 'hiera-eyaml',
@@ -248,7 +250,7 @@ class hiera (
   # Determine hiera version
   case $hiera_version {
     '5':  { if ($hierarchy !~ Hiera::Hiera5_hierarchy) {
-              fail('${hierarchy} should be an array of hash')
+              fail("${hierarchy} should be an array of hash")
             }
             else
               { $hiera_template = epp('hiera/hiera.yaml.epp',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,10 @@ class hiera::params {
   if str2bool($facts['is_pe']) {
     $hiera_yaml     = '/etc/puppetlabs/puppet/hiera.yaml'
     $datadir        = '/etc/puppetlabs/puppet/hieradata'
-    $owner          = 'pe-puppet'
-    $group          = 'pe-puppet'
+    $owner          = 'root'
+    $group          = 'root'
+    $eyaml_owner    = 'pe-puppet'
+    $eyaml_group    = 'pe-puppet'
     $cmdpath        = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
     $manage_package = false
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,44 +20,27 @@ class hiera::params {
   $package_ensure   = 'present'
   $package_name     = 'hiera'
   $hierarchy        = []
-  if str2bool($facts['is_pe']) {
-    $hiera_yaml     = '/etc/puppetlabs/puppet/hiera.yaml'
-    $datadir        = '/etc/puppetlabs/puppet/hieradata'
+  # Configure for AIO packaging.
+  if $facts['pe_server_version'] {
+    $master_service = 'pe-puppetserver'
+    $provider       = 'puppetserver_gem'
     $owner          = 'root'
     $group          = 'root'
     $eyaml_owner    = 'pe-puppet'
     $eyaml_group    = 'pe-puppet'
-    $cmdpath        = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
-    $manage_package = false
-
-    if $::pe_version and versioncmp($::pe_version, '3.7.0') >= 0 {
-      $provider       = 'pe_puppetserver_gem'
-      $master_service = 'pe-puppetserver'
-    } else {
-      $provider       = 'pe_gem'
-      $master_service = 'pe-httpd'
-    }
-  } else {
-    # Configure for AIO packaging.
-    if getvar('::pe_server_version') {
-      $master_service = 'pe-puppetserver'
-      $provider       = 'puppetserver_gem'
-    } else {
-      # It would probably be better to assume this is puppetserver, but that
-      # would be a backwards-incompatible change.
-      $master_service = 'puppetmaster'
-      $provider       = 'puppet_gem'
-    }
-    $cmdpath        = ['/opt/puppetlabs/puppet/bin', '/usr/bin', '/usr/local/bin']
-    $datadir        = '/etc/puppetlabs/code/environments/%{::environment}/hieradata'
-    $manage_package = false
-    if getvar('::pe_server_version') {
-      $owner = 'root'
-      $group = 'root'
-    } else {
-      $owner = 'puppet'
-      $group = 'puppet'
-    }
-    $hiera_yaml = "${confdir}/hiera.yaml"
   }
+  else {
+    # It would probably be better to assume this is puppetserver, but that
+    # would be a backwards-incompatible change.
+    $master_service = 'puppetmaster'
+    $provider       = 'puppet_gem'
+    $owner          = 'puppet'
+    $group          = 'puppet'
+    $eyaml_owner    = 'puppet'
+    $eyaml_group    = 'puppet'
+  }
+  $cmdpath        = ['/opt/puppetlabs/puppet/bin', '/usr/bin', '/usr/local/bin']
+  $datadir        = '/etc/puppetlabs/code/environments/%{::environment}/hieradata'
+  $manage_package = false
+  $hiera_yaml = "${confdir}/hiera.yaml"
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,8 +52,8 @@ class hiera::params {
     $datadir        = '/etc/puppetlabs/code/environments/%{::environment}/hieradata'
     $manage_package = false
     if getvar('::pe_server_version') {
-      $owner = 'pe-puppet'
-      $group = 'pe-puppet'
+      $owner = 'root'
+      $group = 'root'
     } else {
       $owner = 'puppet'
       $group = 'puppet'


### PR DESCRIPTION
Fixes #245 
Replaces #246 

Sets better defaults for `/etc/hiera.yaml`, eyaml keys, etc., to prevent conflict with the latest Puppet Enterprise versions.