### PR TITLE
hiera.yaml is word readable. Allow setting different permissions to hide secrets

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class hiera (
   $datadir_manage                           = true,
   $owner                                    = $::hiera::params::owner,
   $group                                    = $::hiera::params::group,
+  $mode                                     = $::hiera::params::mode,
   $eyaml_owner                              = $::hiera::params::eyaml_owner,
   $eyaml_group                              = $::hiera::params::eyaml_group,
   $provider                                 = $::hiera::params::provider,
@@ -144,7 +145,7 @@ class hiera (
   File {
     owner => $owner,
     group => $group,
-    mode  => '0644',
+    mode  => $mode,
   }
 
   if ($datadir !~ /%\{.*\}/) and ($datadir_manage == true) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class hiera::params {
   $package_ensure   = 'present'
   $package_name     = 'hiera'
   $hierarchy        = []
+  $mode             = '0644'
   # Configure for AIO packaging.
   if $facts['pe_server_version'] {
     $master_service = 'pe-puppetserver'

--- a/spec/acceptance/hiera_spec.rb
+++ b/spec/acceptance/hiera_spec.rb
@@ -30,6 +30,7 @@ describe 'hiera' do
         eyaml              => true,
         merge_behavior     => 'deep',
         puppet_conf_manage => true,
+        mode               => '0640',
         hierarchy          => [
           'virtual/%{::virtual}',
           'nodes/%{::trusted.certname}',

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -261,12 +261,19 @@ describe 'hiera' do
           let(:params) do
             {
               eyaml: true,
+              mode: '0640',
               merge_behavior: 'deeper'
             }
           end
 
           it { is_expected.to contain_class('hiera::eyaml') }
           it { is_expected.to contain_class('hiera::deep_merge') }
+          it 'has file mode 0640' do
+            is_expected.to contain_file('/dev/null/hiera.yaml').with(
+              'ensure' => 'file',
+              'mode'   => '0640'
+            )
+          end
         end
         describe 'check if version exists' do
           let(:params) do


### PR DESCRIPTION
## Affected Puppet, Ruby, OS and module versions/distributions

- Puppet: ANY
- Ruby: ANY
- Distribution: ANY
- Module version: 3.4.1

## How to reproduce (e.g Puppet code you use)
`puppet agent -t` :cat: 

## What are you seeing
file permissions being set to 0644

## What behaviour did you expect instead
let the user assign different permissions. I do have Redis token and Hashicorp Vault token set in hiera.yaml
