### PR TITLE
Format options value as json if it is a hash

### DIFF
--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -410,6 +410,29 @@ describe 'hiera' do
               expect(content).to include(hierarchy_section)
             end
           end
+          describe 'hierarchy section with hash as an options value' do
+            let(:params) do
+              {
+                hiera_version: '5',
+                hiera5_defaults: { 'datadir' => 'data', 'data_hash' => 'yaml_data' },
+                hierarchy:  [{
+                  'name'       => 'some backend',
+                  'lookup_key' => 'some_lookup_key',
+                  'options'    => {
+                    'hash_option' => {
+                      'some_key' => 'some_value'
+                    }
+                  }
+                }]
+              }
+            end
+
+            it 'contains the option value as a hash' do
+              content = catalogue.resource('file', '/dev/null/hiera.yaml').send(:parameters)[:content]
+              options = YAML.load(content)['hierarchy'][0]['options']
+              expect(options).to include('hash_option' => { 'some_key' => 'some_value' })
+            end
+          end
         end
       end
     end

--- a/templates/hiera.yaml.epp
+++ b/templates/hiera.yaml.epp
@@ -75,6 +75,9 @@ hierarchy:
         - "<%= $value %>"
       <%- } -%>
     <%- } -%>
+    <%- elsif $value =~ Hash { -%>
+      <%= $key %>: <%= $value.to_json %>
+    <%- } -%>
     <%- else { -%>
       <%= $key %>: <%= $value %>
     <%- } -%>


### PR DESCRIPTION
Plugins like hiera_vault have option values that are themself hashes. Currently the template will simply write this down as a string value, which leads to a broken configuration.

The implementation in this PR uses the fact that JSON is a valid subset of YAML. This may not look pretty as everything ends up on the same line, but it will always be valid.

I'm also not sure if it would be better to use the same methods if the value is an array, which could hold hashes as values as well and that isn't really handled correctly at the moment.

Let me know what you think.