### PR TITLE
Add possibility to stop recursion on gnupghome

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,6 @@ done in lockstep.
 **Note:** This module will create a /gpg sub-directory in the ```$keysdir```.
 
 1. The GPG keyring must be passphraseless on the on the PuppetServer(Master).
-
-**Note:** You might need an older version of GPG to be able to create
-passphraseless keys. You can install an old lxc container or something,
-to do this. Just copy the resulting .gnupg folder to the puppetserver and
-rename it to your gpg folder.
-
 1. The GPG keyring must live in the /gpg sub-directory in the ```$keysdir```.
 1. The GPG keyring must be owned by the Puppet user. ex: pe-puppet
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ done in lockstep.
 
 1. The GPG keyring must be passphraseless on the on the PuppetServer(Master).
 
-**Note:** You might need an older version of GPG to be able to create 
+**Note:** You might need an older version of GPG to be able to create
 passphraseless keys. You can install an old lxc container or something,
 to do this. Just copy the resulting .gnupg folder to the puppetserver and
 rename it to your gpg folder.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ done in lockstep.
 
 1. The GPG keyring must be passphraseless on the on the PuppetServer(Master).
 
+**Note:** You might need an older version of GPG to be able to create 
+passphraseless keys. You can install an old lxc container or something,
+to do this. Just copy the resulting .gnupg folder to the puppetserver and
+rename it to your gpg folder.
+
 1. The GPG keyring must live in the /gpg sub-directory in the ```$keysdir```.
 1. The GPG keyring must be owned by the Puppet user. ex: pe-puppet
 
@@ -364,6 +369,12 @@ The following parameters are available for the hiera class:
 * `eyaml_extension`
   The file extension for the eyaml backend.
   Default: `undef`, backend defaults to `'.eyaml'`
+* `eyaml_gpg_gnupghome_recurse`
+  Whether to recurse and set permissions in the gpgdir.
+  This is imporant to protect the key, but makes puppet agent
+  raise an error on each run. You can set the mode on these files
+  to 0600 by yourself and set this to false.
+  Default: true
 * `deep_merge_name`
   The name of the deep_merge gem.
   Default: 'deep\_merge'

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ cat << EOF >> /tmp/gpg_answers
 %echo Generating a Puppet Hiera GPG Key
 Key-Type: RSA
 Key-Length: 4096
+Key-Usage: encrypt
 Subkey-Type: ELG-E
 Subkey-Length: 4096
 Name-Real: Hiera Data

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ cat << EOF >> /tmp/gpg_answers
 %echo Generating a Puppet Hiera GPG Key
 Key-Type: RSA
 Key-Length: 4096
-Key-Usage: encrypt
 Subkey-Type: ELG-E
 Subkey-Length: 4096
 Name-Real: Hiera Data

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -51,7 +51,6 @@ class hiera::eyaml {
   $keysdir = dirname($_keysdir)
 
   if ( $create_keys == true ) {
-
     exec { 'createkeys':
       user    => $owner,
       cwd     => $keysdir,

--- a/manifests/eyaml_gpg.pp
+++ b/manifests/eyaml_gpg.pp
@@ -3,21 +3,22 @@
 # This calls install and configures hiera-eyaml-gpg
 #
 class hiera::eyaml_gpg {
-  $provider          = $hiera::provider
-  $eyaml_gpg_name    = $hiera::eyaml_gpg_name
-  $eyaml_gpg_version = $hiera::eyaml_gpg_version
-  $eyaml_gpg_source  = $hiera::_eyaml_gpg_source
+  $provider                     = $hiera::provider
+  $eyaml_gpg_name               = $hiera::eyaml_gpg_name
+  $eyaml_gpg_version            = $hiera::eyaml_gpg_version
+  $eyaml_gpg_source             = $hiera::_eyaml_gpg_source
+  $eyaml_gpg_gnupghome_recurse  = $hiera::eyaml_gpg_gnupghome_recurse
 
-  $ruby_gpg_name     = $hiera::ruby_gpg_name
-  $ruby_gpg_version  = $hiera::ruby_gpg_version
-  $ruby_gpg_source   = $hiera::ruby_gpg_source
+  $ruby_gpg_name                = $hiera::ruby_gpg_name
+  $ruby_gpg_version             = $hiera::ruby_gpg_version
+  $ruby_gpg_source              = $hiera::ruby_gpg_source
 
-  $owner             = $hiera::eyaml_owner
-  $group             = $hiera::eyaml_group
-  $cmdpath           = $hiera::cmdpath
-  $_keysdir          = $hiera::_keysdir
+  $owner                        = $hiera::eyaml_owner
+  $group                        = $hiera::eyaml_group
+  $cmdpath                      = $hiera::cmdpath
+  $_keysdir                     = $hiera::_keysdir
 
-  $manage_package = $hiera::manage_eyaml_gpg_package
+  $manage_package               = $hiera::manage_eyaml_gpg_package
 
   require hiera::eyaml
 
@@ -43,7 +44,7 @@ class hiera::eyaml_gpg {
 
   file { "${_keysdir}/gpg":
     ensure  => directory,
-    recurse => true,
+    recurse => $eyaml_gpg_gnupghome_recurse,
     purge   => false,
     mode    => '0600',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,7 @@ class hiera (
   $eyaml_gpg_version                        = undef,
   $eyaml_gpg_source                         = undef,
   $eyaml_gpg                                = false,
+  $eyaml_gpg_gnupghome_recurse              = true,
   $eyaml_gpg_recipients                     = undef,
   $eyaml_pkcs7_private_key                  = undef,
   $eyaml_pkcs7_public_key                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,7 +205,7 @@ class hiera (
   # the above logic.  This was neccessary in order to maintain compability
   # with prior versions of this module
   $eyaml_options = {
-    'eyaml' => delete_undef_values({
+    'eyaml' => delete_undef_values( {
       'datadir'           => $eyaml_real_datadir,
       'extension'         => $eyaml_extension,
       'pkcs7_private_key' => $_eyaml_pkcs7_private_key,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -206,13 +206,13 @@ class hiera (
   # with prior versions of this module
   $eyaml_options = {
     'eyaml' => delete_undef_values( {
-      'datadir'           => $eyaml_real_datadir,
-      'extension'         => $eyaml_extension,
-      'pkcs7_private_key' => $_eyaml_pkcs7_private_key,
-      'pkcs7_public_key'  => $_eyaml_pkcs7_public_key,
-      'encrypt_method'    => $encrypt_method,
-      'gpg_gnupghome'     => $gpg_gnupghome,
-      'gpg_recipients'    => $eyaml_gpg_recipients,
+        'datadir'           => $eyaml_real_datadir,
+        'extension'         => $eyaml_extension,
+        'pkcs7_private_key' => $_eyaml_pkcs7_private_key,
+        'pkcs7_public_key'  => $_eyaml_pkcs7_public_key,
+        'encrypt_method'    => $encrypt_method,
+        'gpg_gnupghome'     => $gpg_gnupghome,
+        'gpg_recipients'    => $eyaml_gpg_recipients,
     }),
   }
   $yaml_options = { 'yaml' => { 'datadir' => $datadir } }
@@ -226,8 +226,8 @@ class hiera (
   # catch that error here and notify the user
   $missing_backends = difference($backends, keys($backend_data))
   if count($missing_backends) > 0 {
-    fail("The supplied backends: ${missing_backends} are missing from the backend_options hash:\n ${backend_options}\n
-    or you might be using symbols in your hiera data")
+  fail("The supplied backends: ${missing_backends} are missing from the backend_options hash:\n ${backend_options}\n
+  or you might be using symbols in your hiera data")
   }
 
   # Template uses:
@@ -249,16 +249,16 @@ class hiera (
   # Determine hiera version
   case $hiera_version {
     '5':  { if ($hierarchy !~ Hiera::Hiera5_hierarchy) {
-              fail('`hierarchy` should be an array of hash')
-            } else {
-              $hiera_template = epp('hiera/hiera.yaml.epp',
-                                      {
-                                        'hiera_version'   => $hiera_version,
-                                        'hiera5_defaults' => $hiera5_defaults,
-                                        'hierarchy'       => $hierarchy
-                                      })
-              }
-          }                                                             # Apply epp if hiera version is 5
+        fail('`hierarchy` should be an array of hash')
+      } else {
+        $hiera_template = epp('hiera/hiera.yaml.epp',
+            {
+            'hiera_version'   => $hiera_version,
+            'hiera5_defaults' => $hiera5_defaults,
+            'hierarchy'       => $hierarchy
+            })
+      }
+    }                                                             # Apply epp if hiera version is 5
     default:  { $hiera_template = template('hiera/hiera.yaml.erb') }    # Apply erb for default version 3
   }
   file { $hiera_yaml:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -252,11 +252,11 @@ class hiera (
         fail('`hierarchy` should be an array of hash')
       } else {
         $hiera_template = epp('hiera/hiera.yaml.epp',
-            {
+          {
             'hiera_version'   => $hiera_version,
             'hiera5_defaults' => $hiera5_defaults,
             'hierarchy'       => $hierarchy
-            })
+        })
       }
     }                                                             # Apply epp if hiera version is 5
     default:  { $hiera_template = template('hiera/hiera.yaml.erb') }    # Apply erb for default version 3

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,7 +205,6 @@ class hiera (
   # the above logic.  This was neccessary in order to maintain compability
   # with prior versions of this module
   $eyaml_options = {
-
     'eyaml' => delete_undef_values({
       'datadir'           => $eyaml_real_datadir,
       'extension'         => $eyaml_extension,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,7 +112,6 @@ class hiera (
   #Deprecated
   $gem_source                               = undef,
 ) inherits ::hiera::params {
-
   if $keysdir {
     $_keysdir = $keysdir
   } else {
@@ -165,7 +164,6 @@ class hiera (
   }
 
   if ( $eyaml_gpg ) or ( $eyaml ) {
-
     $eyaml_real_datadir = empty($eyaml_datadir) ? {
       false => $eyaml_datadir,
       true  => $datadir,
@@ -177,7 +175,6 @@ class hiera (
     } else {
       $requested_backends = unique(concat(['eyaml'], $backends))
     }
-
   } else {
     $requested_backends = $backends
     $eyaml_real_datadir = undef
@@ -208,6 +205,7 @@ class hiera (
   # the above logic.  This was neccessary in order to maintain compability
   # with prior versions of this module
   $eyaml_options = {
+
     'eyaml' => delete_undef_values({
       'datadir'           => $eyaml_real_datadir,
       'extension'         => $eyaml_extension,
@@ -253,9 +251,8 @@ class hiera (
   case $hiera_version {
     '5':  { if ($hierarchy !~ Hiera::Hiera5_hierarchy) {
               fail('`hierarchy` should be an array of hash')
-            }
-            else
-              { $hiera_template = epp('hiera/hiera.yaml.epp',
+            } else {
+              $hiera_template = epp('hiera/hiera.yaml.epp',
                                       {
                                         'hiera_version'   => $hiera_version,
                                         'hiera5_defaults' => $hiera5_defaults,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,7 +99,7 @@ class hiera (
   $eyaml_gpg_version                        = undef,
   $eyaml_gpg_source                         = undef,
   $eyaml_gpg                                = false,
-  $eyaml_gpg_gnupghome_recurse              = true,
+  Boolean $eyaml_gpg_gnupghome_recurse      = true,
   $eyaml_gpg_recipients                     = undef,
   $eyaml_pkcs7_private_key                  = undef,
   $eyaml_pkcs7_public_key                   = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,6 @@ define hiera::install (
   $gem_source          = undef,
   $gem_install_options = $hiera::gem_install_options,
 ) {
-
   # $gem_install_options is typically used for specifying a proxy
   Package {
     install_options => $gem_install_options,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@
 class hiera::params {
   $confdir          = $::settings::confdir
   $hiera_version    = '3'
-  $hiera5_defaults  = {'datadir' => 'data', 'data_hash' => 'yaml_data'}
+  $hiera5_defaults  = { 'datadir' => 'data', 'data_hash' => 'yaml_data' }
   $package_ensure   = 'present'
   $package_name     = 'hiera'
   $hierarchy        = []

--- a/spec/classes/deep_merge_spec.rb
+++ b/spec/classes/deep_merge_spec.rb
@@ -4,30 +4,30 @@ require 'spec_helper'
 require 'puppet'
 
 describe 'hiera::deep_merge' do
-
   context 'merge_behavior => deep' do
     let(:pre_condition) do
       'class { "hiera": merge_behavior => "deep", manage_deep_merge_package => true }'
     end
+
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_package('deep_merge').with(
-        'ensure'  => 'installed',
+    it do
+      is_expected.to contain_package('deep_merge').with(
+        'ensure'  => 'installed'
       )
-    }
+    end
     it { is_expected.to contain_hiera__install('deep_merge') }
-
   end
-
   context 'merge_behavior => deeper' do
     let(:pre_condition) do
       'class { "hiera": merge_behavior => "deep", manage_deep_merge_package => true }'
     end
-    it { is_expected.to contain_package('deep_merge').with(
-        'ensure'  => 'installed',
+
+    it do
+      is_expected.to contain_package('deep_merge').with(
+        'ensure'  => 'installed'
       )
-    }
+    end
     it { is_expected.to contain_hiera__install('deep_merge') }
   end
-
 end

--- a/spec/classes/deep_merge_spec.rb
+++ b/spec/classes/deep_merge_spec.rb
@@ -11,8 +11,10 @@ describe 'hiera::deep_merge' do
     end
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_package('deep_merge')
-      .with('ensure'  => 'installed',)}
+    it { is_expected.to contain_package('deep_merge').with(
+        'ensure'  => 'installed',
+      )
+    }
     it { is_expected.to contain_hiera__install('deep_merge') }
 
   end
@@ -21,8 +23,10 @@ describe 'hiera::deep_merge' do
     let(:pre_condition) do
       'class { "hiera": merge_behavior => "deep", manage_deep_merge_package => true }'
     end
-    it { is_expected.to contain_package('deep_merge')
-      .with('ensure'  => 'installed',)}
+    it { is_expected.to contain_package('deep_merge').with(
+        'ensure'  => 'installed',
+      )
+    }
     it { is_expected.to contain_hiera__install('deep_merge') }
   end
 

--- a/spec/classes/deep_merge_spec.rb
+++ b/spec/classes/deep_merge_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+require 'puppet'
+
+describe 'hiera::deep_merge' do
+
+  context 'merge_behavior => deep' do
+    let(:pre_condition) do
+      'class { "hiera": merge_behavior => "deep", manage_deep_merge_package => true }'
+    end
+    it { is_expected.to compile }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_package('deep_merge')
+      .with('ensure'  => 'installed',)}
+    it { is_expected.to contain_hiera__install('deep_merge') }
+
+  end
+
+  context 'merge_behavior => deeper' do
+    let(:pre_condition) do
+      'class { "hiera": merge_behavior => "deep", manage_deep_merge_package => true }'
+    end
+    it { is_expected.to contain_package('deep_merge')
+      .with('ensure'  => 'installed',)}
+    it { is_expected.to contain_hiera__install('deep_merge') }
+  end
+
+end

--- a/spec/classes/eyaml_gpg_spec.rb
+++ b/spec/classes/eyaml_gpg_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+require 'puppet'
+
+describe 'hiera::eyaml_gpg' do
+
+
+  context 'default params' do
+    let(:pre_condition) do
+      'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys" }'
+    end
+    it { is_expected.to compile }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_file('/dev/null/keys') }
+    it { is_expected.to contain_file('/dev/null/keys/gpg')
+      .with(
+        'ensure'  => 'directory',
+        'recurse' => true,
+        'purge'   => false,
+        'mode'    => '0600',
+      )}
+    it { is_expected.to contain_package('hiera-eyaml-gpg')}
+    it { is_expected.to contain_package('ruby_gpg')}
+  end
+
+  context 'eyaml_gpg_gnupghome_recurse is false' do
+    let(:pre_condition) do
+      'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false,}'
+    end
+    it { is_expected.to contain_file('/dev/null/keys/gpg')
+      .with(
+        'recurse' => false,
+      )}
+
+  end
+end

--- a/spec/classes/eyaml_gpg_spec.rb
+++ b/spec/classes/eyaml_gpg_spec.rb
@@ -5,7 +5,6 @@ require 'puppet'
 
 describe 'hiera::eyaml_gpg' do
 
-
   context 'default params' do
     let(:pre_condition) do
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys" }'
@@ -13,13 +12,13 @@ describe 'hiera::eyaml_gpg' do
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_file('/dev/null/keys') }
-    it { is_expected.to contain_file('/dev/null/keys/gpg')
-      .with(
+    it { is_expected.to contain_file('/dev/null/keys/gpg').with(
         'ensure'  => 'directory',
         'recurse' => true,
         'purge'   => false,
         'mode'    => '0600',
-      )}
+      )
+    }
     it { is_expected.to contain_package('hiera-eyaml-gpg')}
     it { is_expected.to contain_package('ruby_gpg')}
   end
@@ -28,10 +27,9 @@ describe 'hiera::eyaml_gpg' do
     let(:pre_condition) do
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false,}'
     end
-    it { is_expected.to contain_file('/dev/null/keys/gpg')
-      .with(
+    it { is_expected.to contain_file('/dev/null/keys/gpg').with(
         'recurse' => false,
-      )}
-
+      )
+    }
   end
 end

--- a/spec/classes/eyaml_gpg_spec.rb
+++ b/spec/classes/eyaml_gpg_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'spec_helper'
 require 'puppet'
@@ -6,13 +6,17 @@ require 'puppet'
 describe 'hiera::eyaml_gpg' do
 
   context 'default params' do
+
     let(:pre_condition) do
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys" }'
+
     end
+
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_file('/dev/null/keys') }
-    it { is_expected.to contain_file('/dev/null/keys/gpg').with(
+    it { is_expected.to contain_file('/dev/null/keys/gpg').
+      with(
         'ensure'  => 'directory',
         'recurse' => true,
         'purge'   => false,
@@ -21,15 +25,21 @@ describe 'hiera::eyaml_gpg' do
     }
     it { is_expected.to contain_package('hiera-eyaml-gpg')}
     it { is_expected.to contain_package('ruby_gpg')}
+
   end
 
   context 'eyaml_gpg_gnupghome_recurse is false' do
+
     let(:pre_condition) do
+
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false,}'
     end
-    it { is_expected.to contain_file('/dev/null/keys/gpg').with(
+
+    it { is_expected.to contain_file('/dev/null/keys/gpg').
+      with(
         'recurse' => false,
       )
     }
+
   end
 end

--- a/spec/classes/eyaml_gpg_spec.rb
+++ b/spec/classes/eyaml_gpg_spec.rb
@@ -4,14 +4,10 @@ require 'spec_helper'
 require 'puppet'
 
 describe 'hiera::eyaml_gpg' do
-
   context 'default params' do
-
     let(:pre_condition) do
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys" }'
-
     end
-
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_file('/dev/null/keys') }
@@ -25,21 +21,15 @@ describe 'hiera::eyaml_gpg' do
     }
     it { is_expected.to contain_package('hiera-eyaml-gpg')}
     it { is_expected.to contain_package('ruby_gpg')}
-
   end
-
   context 'eyaml_gpg_gnupghome_recurse is false' do
-
     let(:pre_condition) do
-
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false,}'
     end
-
     it { is_expected.to contain_file('/dev/null/keys/gpg').
       with(
         'recurse' => false,
       )
     }
-
   end
 end

--- a/spec/classes/eyaml_gpg_spec.rb
+++ b/spec/classes/eyaml_gpg_spec.rb
@@ -8,28 +8,30 @@ describe 'hiera::eyaml_gpg' do
     let(:pre_condition) do
       'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys" }'
     end
+
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_file('/dev/null/keys') }
-    it { is_expected.to contain_file('/dev/null/keys/gpg').
-      with(
+    it do
+      is_expected.to contain_file('/dev/null/keys/gpg').with(
         'ensure'  => 'directory',
         'recurse' => true,
         'purge'   => false,
-        'mode'    => '0600',
+        'mode'    => '0600'
       )
-    }
-    it { is_expected.to contain_package('hiera-eyaml-gpg')}
-    it { is_expected.to contain_package('ruby_gpg')}
+    end
+    it { is_expected.to contain_package('hiera-eyaml-gpg') }
+    it { is_expected.to contain_package('ruby_gpg') }
   end
   context 'eyaml_gpg_gnupghome_recurse is false' do
     let(:pre_condition) do
-      'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false,}'
+      'class { "hiera": eyaml_gpg  => true, keysdir => "/dev/null/keys", eyaml_gpg_gnupghome_recurse => false}'
     end
-    it { is_expected.to contain_file('/dev/null/keys/gpg').
-      with(
-        'recurse' => false,
+
+    it do
+      is_expected.to contain_file('/dev/null/keys/gpg').with(
+        'recurse' => false
       )
-    }
+    end
   end
 end

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -28,7 +28,7 @@ describe 'hiera' do
     describe 'param manage_package => true' do
       let(:params) do
         {
-          manage_package: true,
+          manage_package: true
         }
       end
 

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -25,13 +25,22 @@ describe 'hiera' do
       it { is_expected.to contain_class('hiera::eyaml') }
       it { is_expected.to contain_class('hiera::deep_merge') }
     end
+    describe 'param manage_package => true' do
+      let(:params) do
+        {
+          manage_package: true,
+        }
+      end
+
+      it { is_expected.to contain_package('hiera').with('ensure' => 'present') }
+    end
     describe 'param manage_package => false' do
       let(:params) do
         {
           eyaml: true,
           eyaml_gpg: true,
           manage_package: false,
-          keysdir: '/etc/keys'
+          keysdir: '/dev/null/keys'
         }
       end
 
@@ -40,18 +49,18 @@ describe 'hiera' do
       it { is_expected.to contain_hiera__install('eyaml') }
       it { is_expected.to contain_hiera__install('ruby_gpg') }
       it { is_expected.to contain_hiera__install('hiera-eyaml-gpg') }
-      it { is_expected.to contain_exec('createkeys').that_requires('File[/etc/keys]') }
+      it { is_expected.to contain_exec('createkeys').that_requires('File[/dev/null/keys]') }
     end
     describe 'param manage_package => true and create_keys => true' do
       let(:params) do
         {
           eyaml: true,
           manage_package: true,
-          keysdir: '/etc/keys'
+          keysdir: '/dev/null/keys'
         }
       end
 
-      it { is_expected.to contain_exec('createkeys').that_requires('Hiera::Install[eyaml]').that_requires('File[/etc/keys]') }
+      it { is_expected.to contain_exec('createkeys').that_requires('Hiera::Install[eyaml]').that_requires('File[/dev/null/keys]') }
     end
     describe 'other_backends' do
       let(:params) do


### PR DESCRIPTION

#### Pull Request (PR) description
When puppet runs it gets an error that it can't handle sockets. Since gpg-agent is integral to gpg now,
that is an error that is unavoidable with thee current setup.
If you do this manually, ie. `chmod -r 0600 $GNUPGHOME`, then there is no need to run this and get an error
every run.
