### PR TITLE
Remove blank newline from epp template

### DIFF
--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -378,13 +378,13 @@ describe 'hiera' do
 
             it 'renders correctly' do
               content = catalogue.resource('file', '/dev/null/hiera.yaml').send(:parameters)[:content]
-              hierarchy_section  = %(hierarchy:\n\n)
+              hierarchy_section  = %(hierarchy:\n)
               hierarchy_section += %(  - name: "Virtual yaml"\n)
-              hierarchy_section += %(    path: "virtual/%{virtual}.yaml"\n\n)
+              hierarchy_section += %(    path: "virtual/%{virtual}.yaml"\n)
               hierarchy_section += %(  - name: "Nodes yaml"\n)
               hierarchy_section += %(    paths:\n)
               hierarchy_section += %(      - "nodes/%{trusted.certname}.yaml"\n)
-              hierarchy_section += %(      - "nodes/%{osfamily}.yaml"\n\n)
+              hierarchy_section += %(      - "nodes/%{osfamily}.yaml"\n)
               hierarchy_section += %(  - name: "Global yaml file"\n)
               hierarchy_section += %(    path: "common.yaml"\n)
               expect(content).to include(hierarchy_section)
@@ -406,15 +406,15 @@ describe 'hiera' do
 
             it 'renders correctly' do
               content = catalogue.resource('file', '/dev/null/hiera.yaml').send(:parameters)[:content]
-              hierarchy_section  = %(hierarchy:\n\n)
+              hierarchy_section  = %(hierarchy:\n)
               hierarchy_section += %(  - name: "Virtual yaml"\n)
-              hierarchy_section += %(    path: "virtual/%{virtual}.yaml"\n\n)
+              hierarchy_section += %(    path: "virtual/%{virtual}.yaml"\n)
               hierarchy_section += %(  - name: "Nodes yaml"\n)
               hierarchy_section += %(    paths:\n)
               hierarchy_section += %(      - "nodes/%{trusted.certname}.yaml"\n)
-              hierarchy_section += %(      - "nodes/%{osfamily}.yaml"\n\n)
+              hierarchy_section += %(      - "nodes/%{osfamily}.yaml"\n)
               hierarchy_section += %(  - name: "Global yaml file"\n)
-              hierarchy_section += %(    path: "common.yaml"\n\n)
+              hierarchy_section += %(    path: "common.yaml"\n)
               hierarchy_section += %(  - name: "trocla"\n)
               hierarchy_section += %(    lookup_key: trocla_lookup_key\n)
               hierarchy_section += %(    options:\n)

--- a/templates/hiera.yaml.epp
+++ b/templates/hiera.yaml.epp
@@ -20,7 +20,7 @@ defaults:
 <% } -%>
 <% } -%>
 hierarchy:
-<%- $hierarchy.each |$hr| { %>
+<%- $hierarchy.each |$hr| { -%>
 <% if $hr['name'] { -%>
   - name: "<%= $hr['name'] -%>"
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This is just a nit, but `omit blank lines ending in -%>` resulting in a empty line being removed from the template for hiera5

```yaml
# hiera.yaml Managed by Puppet
version: 5
defaults:
  datadir: /etc/puppetlabs/code/environments/%{::environment}/hieradata
hierarchy:

  - name: "VDefault Hierarchy and Backend (eyaml)"
```

resulting in
```diff
--- /etc/puppetlabs/puppet/hiera.yaml	2021-10-04 18:24:50.975410368 -0700
+++ /tmp/puppet-file20211005-23697-1nj6xp3	2021-10-05 10:13:17.326377551 -0700
@@ -3,7 +3,6 @@
 defaults:
   datadir: /etc/puppetlabs/code/environments/%{::environment}/hieradata
 hierarchy:
-
   - name: "VDefault Hierarchy and Backend (eyaml)"
     paths:
       - "fqdn/%{::cluster}/%{::fqdn}.yaml"
```

#### This Pull Request (PR) fixes the following issues
N/A, but I'm happy to create one to reference if needed
