### PR TITLE
Update metadata.json to include RHEL 8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
 Pull Request (PR) description

Update metadata.json to include RHEL 8 support

puppet-hiera works with rhel-8 but is not officially in the metadata as a supported OS.
