### PR TITLE
Drop pidfile_workaround from Beaker testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,3 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
-    with:
-      pidfile_workaround: 'CentOS'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,2 +1,0 @@
-.github/workflows/ci.yml:
-  pidfile_workaround: CentOS


### PR DESCRIPTION
To see if it's indeed no longer a problem, as suggested in https://github.com/voxpupuli/puppet_metadata/pull/103.