### PR TITLE
removed beaker configure block with puppetserver and the puppetserver gem

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,14 +2,6 @@
 
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker do |host|
-  install_puppet_module_via_pmt_on(host, 'puppetlabs-puppetserver_gem')
-  unless ENV['BEAKER_provision'] == 'no'
-    install_package(host, 'puppetserver')
-    on host, 'puppet resource service puppetserver ensure=running'
-  end
-end
-
 def wait_for_puppetserver(host, max_retries)
   1.upto(max_retries) do |retries|
     on(host, "curl -skIL https://#{host.hostname}:8140", acceptable_exit_codes: [0, 1, 7]) do |result|


### PR DESCRIPTION
FIxes to PR341 to allow tests to pass