### PR TITLE
Acceptance tests: Install openvox-server package instead of puppetserver package

### DIFF
--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '10.0.0'
+modulesync_config_version: '10.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 3.5',  :require => false
+  gem 'voxpupuli-acceptance', '~> 4.0',  :require => false
 end
 
 group :release do

--- a/Rakefile
+++ b/Rakefile
@@ -1,30 +1,22 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-# Attempt to load voxpupuli-test (which pulls in puppetlabs_spec_helper),
-# otherwise attempt to load it directly.
 begin
   require 'voxpupuli/test/rake'
 rescue LoadError
-  begin
-    require 'puppetlabs_spec_helper/rake_tasks'
-  rescue LoadError
-  end
+  # only available if gem group test is installed
 end
 
-# load optional tasks for acceptance
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/acceptance/rake'
 rescue LoadError
+  # only available if gem group acceptance is installed
 end
 
-# load optional tasks for releases
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/release/rake_tasks'
 rescue LoadError
-  # voxpupuli-release not present
+  # only available if gem group releases is installed
 else
   GCGConfig.user = 'voxpupuli'
   GCGConfig.project = 'puppet-hiera'

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04"
       ]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -51,8 +51,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,7 +5,7 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 configure_beaker do |host|
   install_puppet_module_via_pmt_on(host, 'puppetlabs-puppetserver_gem')
   unless ENV['BEAKER_provision'] == 'no'
-    install_package(host, 'puppetserver')
+    install_package(host, 'openvox-server')
     on host, 'puppet resource service puppetserver ensure=running'
   end
 end


### PR DESCRIPTION
- **Drop support for EOL Ubuntu 20.04**
- **modulesync 10.0.0-19-g1adc8e0**
- **Drop puppet, update openvox minimum version to 8.19**
- **spec_helper_acceptance: install openvox-server instead of puppetserver**
